### PR TITLE
Config path fix + readme update

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -35,7 +35,7 @@ class BaseCommand extends Command {
      * @internal param string $style
      * @return void
      */
-    public function table(array $headers, array $rows, $style = 'default') {
+    public function table(array $headers, $rows, $style = 'default') {
         $table = $this->getHelperSet()->get('table');
         $table->setHeaders($headers);
         $table->setRows($rows);

--- a/src/Laravel5BackupManagerServiceProvider.php
+++ b/src/Laravel5BackupManagerServiceProvider.php
@@ -22,8 +22,7 @@ class Laravel5BackupManagerServiceProvider extends ServiceProvider {
      * @return void
      */
     public function boot() {
-        $configPath = __DIR__ . '/../../../config';
-        $this->publishes([$configPath . "/backup-manager.php" => config_path('backup-manager.php')], 'backup-manager');
+        $this->publishes([config_path() . "/backup-manager.php" => config_path('backup-manager.php')], 'backup-manager');
     }
 
     /**
@@ -33,8 +32,7 @@ class Laravel5BackupManagerServiceProvider extends ServiceProvider {
      */
     public function register() {
 
-        $configPath = __DIR__ . '/../../../config';
-        $this->mergeConfigFrom($configPath . '/backup-manager.php', 'backup-manager');
+        $this->mergeConfigFrom(config_path() . '/backup-manager.php', 'backup-manager');
         $this->registerFilesystemProvider();
         $this->registerDatabaseProvider();
         $this->registerCompressorProvider();
@@ -106,9 +104,9 @@ class Laravel5BackupManagerServiceProvider extends ServiceProvider {
      */
     private function registerArtisanCommands() {
         $this->commands([
-            'BackupManager\Integrations\Laravel\DbBackupCommand',
-            'BackupManager\Integrations\Laravel\DbRestoreCommand',
-            'BackupManager\Integrations\Laravel\DbListCommand',
+            'BackupManager\Laravel\DbBackupCommand',
+            'BackupManager\Laravel\DbRestoreCommand',
+            'BackupManager\Laravel\DbListCommand',
         ]);
     }
 


### PR DESCRIPTION
- Better way to get the config path
- Remove Integration namespace
- Remove 'array' keyword from the table method
- I have made a minor update to the README file to explicitly describe where to copy the backup-manager.php file.
