### PR TITLE
Typecast $rows as an array

### DIFF
--- a/src/Laravel5Compatibility.php
+++ b/src/Laravel5Compatibility.php
@@ -11,7 +11,7 @@ trait Laravel5Compatibility {
      * @internal param string $style
      * @return void
      */
-    public function table(array $headers, $rows, $style = 'default') {
+    public function table(array $headers, array $rows, $style = 'default') {
         $table = $this->getHelperSet()->get('table');
         $table->setHeaders($headers);
         $table->setRows($rows);


### PR DESCRIPTION
Laravel decided that $rows needs to be typecast as an array.

Fixes #8 
