### PR TITLE
Swapped Unix-specific '\' for OS-agnostic PHP_EOL

### DIFF
--- a/src/DbBackupCommand.php
+++ b/src/DbBackupCommand.php
@@ -99,7 +99,7 @@ class DbBackupCommand extends Command {
             $this->option('database'),
             $this->option('compression'),
             $this->option('destination'),
-            $root .'/'. $this->option('destinationPath')
+            $root .PHP_EOL. $this->option('destinationPath')
         ));
     }
 


### PR DESCRIPTION
I haven't checked if this exists anywhere else in the code, I just noticed this when I ran the backup command on Windows
