### PR TITLE
Swapped '/' for PHP_EOL

### DIFF
--- a/src/DbBackupCommand.php
+++ b/src/DbBackupCommand.php
@@ -99,7 +99,7 @@ class DbBackupCommand extends Command {
             $this->option('database'),
             $this->option('compression'),
             $this->option('destination'),
-            $root .'/'. $this->option('destinationPath')
+            $root .DIRECTORY_SEPARATOR. $this->option('destinationPath')
         ));
     }
 


### PR DESCRIPTION
Swapped weird-looking '/' for compiler-generated PHP_EOL

(The message looks stupid in Windows command prompt)

PS: I used the wrong constant in the last pull request, sorry ;D
