### PR TITLE
Update Laravel50Compatibility.php

### DIFF
--- a/src/Laravel50Compatibility.php
+++ b/src/Laravel50Compatibility.php
@@ -11,7 +11,7 @@ trait Laravel50Compatibility {
      * @internal param string $style
      * @return void
      */
-    public function table($headers, $rows, $style = 'default') {
+    public function table(array $headers, array $rows, $style = 'default') {
         $table = $this->getHelperSet()->get('table');
         $table->setHeaders($headers);
         $table->setRows($rows);


### PR DESCRIPTION
To fix error 
[ErrorException]  
Declaration of BackupManager\Laravel\Laravel50Compatibility::table() should be compatible with Illuminate\Console\Command::table(array $headers, array $rows, $style = 'default')
