### PR TITLE
Lumen Service Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ php artisan vendor:publish --provider="BackupManager\Laravel\Laravel5ServiceProv
 
 The Backup Manager will make use of Laravel's database configuration. But, it won't know about any connections that might be tied to other environments, so it can be best to just list multiple connections in the `config/database.php` file.
 
+#### Lumen Configuration
+
+To install into a Lumen project, first do the composer install then add *ONE* of the following service providers to your `boostrap/app.php`.
+
+```php
+// FOR LUMEN 5.0 ONLY
+$app->configure('backup-manager');
+$app->register(BackupManager\Laravel\Lumen50ServiceProvider::class);
+
+// FOR LUMEN 5.1 AND ABOVE
+$app->configure('backup-manager');
+$app->register(BackupManager\Laravel\LumenServiceProvider::class);
+```
+
+Copy the `vendor/backup-manager/laravel/config/backup-manager.php` file to `config/backup-manager.php` and configure it to suit your needs.
+
 **IoC Resolution**
 
 `BackupManager\Manager` can be automatically resolved through constructor injection thanks to Laravel's IoC container.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The Backup Manager will make use of Laravel's database configuration. But, it wo
 
 #### Lumen Configuration
 
-To install into a Lumen project, first do the composer install then add *ONE* of the following service providers to your `bootstrap/app.php`.
+To install into a Lumen project, first do the composer install then add the configuration file loader and *ONE* of the following service providers to your `bootstrap/app.php`.
 
 ```php
 // FOR LUMEN 5.0 ONLY

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The Backup Manager will make use of Laravel's database configuration. But, it wo
 
 #### Lumen Configuration
 
-To install into a Lumen project, first do the composer install then add *ONE* of the following service providers to your `boostrap/app.php`.
+To install into a Lumen project, first do the composer install then add *ONE* of the following service providers to your `bootstrap/app.php`.
 
 ```php
 // FOR LUMEN 5.0 ONLY

--- a/src/Lumen50ServiceProvider.php
+++ b/src/Lumen50ServiceProvider.php
@@ -1,0 +1,144 @@
+<?php namespace BackupManager\Laravel;
+
+use BackupManager\Databases;
+use BackupManager\Filesystems;
+use BackupManager\Compressors;
+use Symfony\Component\Process\Process;
+use Illuminate\Support\ServiceProvider;
+use BackupManager\Config\Config;
+use BackupManager\ShellProcessing\ShellProcessor;
+
+/**
+ * Class BackupManagerServiceProvider
+ * @package BackupManager\Laravel
+ */
+class Lumen50ServiceProvider extends ServiceProvider {
+
+    protected $defer = true;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register() {
+        $configPath = __DIR__ . '/../config/backup-manager.php';
+        $this->mergeConfigFrom($configPath, 'backup-manager');
+        $this->registerFilesystemProvider();
+        $this->registerDatabaseProvider();
+        $this->registerCompressorProvider();
+        $this->registerShellProcessor();
+        $this->registerArtisanCommands();
+    }
+
+    /**
+     * Register the filesystem provider.
+     *
+     * @return void
+     */
+    private function registerFilesystemProvider() {
+        $this->app->bind(\BackupManager\Filesystems\FilesystemProvider::class, function ($app) {
+            $provider = new Filesystems\FilesystemProvider(new Config($app['config']['backup-manager']));
+            $provider->add(new Filesystems\Awss3Filesystem);
+            $provider->add(new Filesystems\DropboxFilesystem);
+            $provider->add(new Filesystems\FtpFilesystem);
+            $provider->add(new Filesystems\LocalFilesystem);
+            $provider->add(new Filesystems\RackspaceFilesystem);
+            $provider->add(new Filesystems\SftpFilesystem);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the database provider.
+     *
+     * @return void
+     */
+    private function registerDatabaseProvider() {
+        $this->app->bind(\BackupManager\Databases\DatabaseProvider::class, function ($app) {
+            $provider = new Databases\DatabaseProvider($this->getDatabaseConfig($app['config']['database.connections']));
+            $provider->add(new Databases\MysqlDatabase);
+            $provider->add(new Databases\PostgresqlDatabase);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the compressor provider.
+     *
+     * @return void
+     */
+    private function registerCompressorProvider() {
+        $this->app->bind(\BackupManager\Compressors\CompressorProvider::class, function () {
+            $provider = new Compressors\CompressorProvider;
+            $provider->add(new Compressors\GzipCompressor);
+            $provider->add(new Compressors\NullCompressor);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the filesystem provider.
+     *
+     * @return void
+     */
+    private function registerShellProcessor() {
+        $this->app->bind(\BackupManager\ShellProcessing\ShellProcessor::class, function () {
+            return new ShellProcessor(new Process(''));
+        });
+    }
+
+    /**
+     * Register the artisan commands.
+     *
+     * @return void
+     */
+    private function registerArtisanCommands() {
+        $this->commands([
+            \BackupManager\Laravel\Laravel50DbBackupCommand::class,
+            \BackupManager\Laravel\Laravel50DbRestoreCommand::class,
+            \BackupManager\Laravel\Laravel50DbListCommand::class,
+        ]);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides() {
+        return [
+            \BackupManager\Filesystems\FilesystemProvider::class,
+            \BackupManager\Databases\DatabaseProvider::class,
+            \BackupManager\ShellProcessing\ShellProcessor::class,
+        ];
+    }
+
+    private function getDatabaseConfig($connections) {
+        $mapped = array_map(function ($connection) {
+            if ( ! in_array($connection['driver'], ['mysql', 'pgsql'])) {
+                return;
+            }
+
+            if (isset($connection['port'])) {
+                $port = $connection['port'];
+            } else {
+                if ($connection['driver'] == 'mysql') {
+                    $port = '3306';
+                } elseif ($connection['driver'] == 'pgsql') {
+                    $port = '5432';
+                }
+            }
+
+            return [
+                'type'     => $connection['driver'],
+                'host'     => $connection['host'],
+                'port'     => $port,
+                'user'     => $connection['username'],
+                'pass'     => $connection['password'],
+                'database' => $connection['database'],
+            ];
+        }, $connections);
+        return new Config($mapped);
+    }
+}

--- a/src/LumenServiceProvider.php
+++ b/src/LumenServiceProvider.php
@@ -1,0 +1,145 @@
+<?php namespace BackupManager\Laravel;
+
+use BackupManager\Databases;
+use BackupManager\Filesystems;
+use BackupManager\Compressors;
+use Symfony\Component\Process\Process;
+use Illuminate\Support\ServiceProvider;
+use BackupManager\Config\Config;
+use BackupManager\ShellProcessing\ShellProcessor;
+
+/**
+ * Class BackupManagerServiceProvider
+ * @package BackupManager\Laravel
+ */
+class LumenServiceProvider extends ServiceProvider {
+
+    protected $defer = true;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register() {
+        $configPath = __DIR__ . '/../config/backup-manager.php';
+        $this->mergeConfigFrom($configPath, 'backup-manager');
+        $this->registerFilesystemProvider();
+        $this->registerDatabaseProvider();
+        $this->registerCompressorProvider();
+        $this->registerShellProcessor();
+        $this->registerArtisanCommands();
+    }
+
+    /**
+     * Register the filesystem provider.
+     *
+     * @return void
+     */
+    private function registerFilesystemProvider() {
+        $this->app->bind(\BackupManager\Filesystems\FilesystemProvider::class, function ($app) {
+            $provider = new Filesystems\FilesystemProvider(new Config($app['config']['backup-manager']));
+            $provider->add(new Filesystems\Awss3Filesystem);
+            $provider->add(new Filesystems\GcsFilesystem);
+            $provider->add(new Filesystems\DropboxFilesystem);
+            $provider->add(new Filesystems\FtpFilesystem);
+            $provider->add(new Filesystems\LocalFilesystem);
+            $provider->add(new Filesystems\RackspaceFilesystem);
+            $provider->add(new Filesystems\SftpFilesystem);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the database provider.
+     *
+     * @return void
+     */
+    private function registerDatabaseProvider() {
+        $this->app->bind(\BackupManager\Databases\DatabaseProvider::class, function ($app) {
+            $provider = new Databases\DatabaseProvider($this->getDatabaseConfig($app['config']['database.connections']));
+            $provider->add(new Databases\MysqlDatabase);
+            $provider->add(new Databases\PostgresqlDatabase);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the compressor provider.
+     *
+     * @return void
+     */
+    private function registerCompressorProvider() {
+        $this->app->bind(\BackupManager\Compressors\CompressorProvider::class, function () {
+            $provider = new Compressors\CompressorProvider;
+            $provider->add(new Compressors\GzipCompressor);
+            $provider->add(new Compressors\NullCompressor);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the filesystem provider.
+     *
+     * @return void
+     */
+    private function registerShellProcessor() {
+        $this->app->bind(\BackupManager\ShellProcessing\ShellProcessor::class, function () {
+            return new ShellProcessor(new Process('', null, null, null, null));
+        });
+    }
+
+    /**
+     * Register the artisan commands.
+     *
+     * @return void
+     */
+    private function registerArtisanCommands() {
+        $this->commands([
+            \BackupManager\Laravel\Laravel5DbBackupCommand::class,
+            \BackupManager\Laravel\Laravel5DbRestoreCommand::class,
+            \BackupManager\Laravel\Laravel5DbListCommand::class,
+        ]);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides() {
+        return [
+            \BackupManager\Filesystems\FilesystemProvider::class,
+            \BackupManager\Databases\DatabaseProvider::class,
+            \BackupManager\ShellProcessing\ShellProcessor::class,
+        ];
+    }
+
+    private function getDatabaseConfig($connections) {
+        $mapped = array_map(function ($connection) {
+            if ( ! in_array($connection['driver'], ['mysql', 'pgsql'])) {
+                return;
+            }
+
+            if (isset($connection['port'])) {
+                $port = $connection['port'];
+            } else {
+                if ($connection['driver'] == 'mysql') {
+                    $port = '3306';
+                } elseif ($connection['driver'] == 'pgsql') {
+                    $port = '5432';
+                }
+            }
+
+            return [
+                'type'     => $connection['driver'],
+                'host'     => $connection['host'],
+                'port'     => $port,
+                'user'     => $connection['username'],
+                'pass'     => $connection['password'],
+                'database' => $connection['database'],
+            ];
+        }, $connections);
+        return new Config($mapped);
+    }
+}


### PR DESCRIPTION
Lumen doesn't have the `vendor:publish` command, so an error is thrown. Removing the `boot` method fixes this issue. Works perfectly otherwise!

To make it work, I just had to manually create the `config/backup-manager.php`, then added these two lines to my `bootstrap/app.php`:

```
$app->configure('backup-manager');
$app->register(BackupManager\Laravel\LumenServiceProvider::class);
```
