### PR TITLE
Fix compatibility with backup-manager v1.1.1

### DIFF
--- a/src/DbBackupCommand.php
+++ b/src/DbBackupCommand.php
@@ -1,5 +1,6 @@
 <?php namespace BackupManager\Laravel;
 
+use BackupManager\Filesystems\Destination;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use BackupManager\Databases\DatabaseProvider;
@@ -85,11 +86,17 @@ class DbBackupCommand extends Command {
             $this->validateArguments();
         }
 
+        $destinations = [
+            new Destination(
+                $this->option('destination'),
+                $this->option('destinationPath')
+            )
+        ];
+
         $this->info('Dumping database and uploading...');
         $this->backupProcedure->run(
             $this->option('database'),
-            $this->option('destination'),
-            $this->option('destinationPath'),
+            $destinations,
             $this->option('compression')
         );
 


### PR DESCRIPTION
Fix DbBackupCommand fire function to work with [backup-manager v1.1.1](https://github.com/backup-manager/backup-manager/releases/tag/1.1.1).

The `backupProcedure->run` function needs an array of Destination object instead of the plain destination and destinationPath since this commit: backup-manager/backup-manager@533c547ccac6627b28c9afbe93527cc576d990b6

Also fix issue #45.
