### PR TITLE
Support for files without extension in db:list

### DIFF
--- a/src/DbListCommand.php
+++ b/src/DbListCommand.php
@@ -76,7 +76,7 @@ class DbListCommand extends Command {
             if ($file['type'] == 'dir') continue;
             $rows[] = [
                 $file['basename'],
-                $file['extension'],
+                key_exists('extension', $file) ? $file['extension'] : null,
                 $this->formatBytes($file['size']),
                 date('D j Y  H:i:s', $file['timestamp'])
             ];


### PR DESCRIPTION
Added support for files without extension in db:list. When a file doesn't have an extension, the key `extension` isn't set. This pull request checks beforehand.
