### PR TITLE
Support for files without extension in db:restore

### DIFF
--- a/src/DbRestoreCommand.php
+++ b/src/DbRestoreCommand.php
@@ -176,7 +176,7 @@ class DbRestoreCommand extends Command {
             if ($file['type'] == 'dir') continue;
             $rows[] = [
                 $file['basename'],
-                $file['extension'],
+                key_exists('extension', $file) ? $file['extension'] : null,
                 $this->formatBytes($file['size']),
                 date('D j Y  H:i:s', $file['timestamp'])
             ];


### PR DESCRIPTION
Sorry for doing this in two pull requests. I forgot to search for more occurrences. :disappointed: 
