### PR TITLE
Fix readme to give correct command

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ It's possible to schedule backups using Laravel's scheduler.
  */
 protected function schedule(Schedule $schedule) {
     $date = Carbon::now()->toW3cString();
-    $environment = env('APP_ENV');
+    $environment = config('app.env');
     $schedule->command(
         "db:backup --database=mysql --destination=s3 --destinationPath=/{$environment}/projectname_{$environment}_{$date} --compression=gzip"
         )->twiceDaily(13,21);


### PR DESCRIPTION
You cant use `env()` safely outside of the config files. As soon as you run `config:cache()` - this causes all `env()` commands to return `null`.

Therefore `env()` shouldnt be used here at all - it'll just trip people up.

This PR fixes the example to make it suitable and safer for all situations.