### PR TITLE
Add timestamp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laravel Driver for the Database Backup Manager
 
-This package pulls in the framework agnostic [Backup Manager](https://github.com/backup-manager/backup-manager) and provides seamless integration with **Laravel**. 
+This package pulls in the framework agnostic [Backup Manager](https://github.com/backup-manager/backup-manager) and provides seamless integration with **Laravel**.
 
 [Watch a video tour](https://www.youtube.com/watch?v=vWXy0R8OavM) to get an idea what is possible with this package.
 
@@ -80,7 +80,7 @@ BackupManager\Laravel\Laravel5ServiceProvider::class,
 
 Publish the storage configuration file.
 
-```php 
+```php
 php artisan vendor:publish --provider="BackupManager\Laravel\Laravel5ServiceProvider"
 ```
 
@@ -129,10 +129,10 @@ All will prompt you with simple questions to successfully execute the command.
 **Example Command for 24hour scheduled cronjob**
 
 ```
-php artisan db:backup --database=mysql --destination=dropbox --destinationPath=`date +\%Y/%d-%m-%Y` --compression=gzip
+php artisan db:backup --database=mysql --destination=dropbox --destinationPath=project --timestamp="d-m-Y" --compression=gzip
 ```
 
-This command will backup your database to dropbox using mysql and gzip compresion in path /backups/YEAR/DATE.gz (ex: /backups/2015/29-10-2015.gz)
+This command will backup your database to dropbox using mysql and gzip compresion in path /backups/project/DATE.gz (ex: /backups/project/31-7-2015.gz)
 
 ### Scheduling Backups
 
@@ -145,15 +145,14 @@ It's possible to schedule backups using Laravel's scheduler.
  * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
  * @return void
  */
-protected function schedule(Schedule $schedule) {
-    $date = Carbon::now()->toW3cString();
-    $environment = config('app.env');
-    $schedule->command(
-        "db:backup --database=mysql --destination=s3 --destinationPath=/{$environment}/projectname_{$environment}_{$date} --compression=gzip"
-        )->twiceDaily(13,21);
-}
+ protected function schedule(Schedule $schedule) {
+     $environment = config('app.env');
+     $schedule->command(
+         "db:backup --database=mysql --destination=s3 --destinationPath=/{$environment}/projectname --timestamp="Y_m_d_H_i_s" --compression=gzip"
+         )->twiceDaily(13,21);
+ }
 ```
-    
+
 ### Contribution Guidelines
 
 We recommend using the vagrant configuration supplied with this package for development and contribution. Simply install VirtualBox, Vagrant, and Ansible then run `vagrant up` in the root folder. A virtualmachine specifically designed for development of the package will be built and launched for you.

--- a/src/DbBackupCommand.php
+++ b/src/DbBackupCommand.php
@@ -36,6 +36,13 @@ class DbBackupCommand extends Command {
     private $required = ['database', 'destination', 'destinationPath', 'compression'];
 
     /**
+     * Optional timestamp.
+     *
+     * @var string
+     */
+    private $timestamp;
+
+    /**
      * The missing arguments.
      *
      * @var array
@@ -80,6 +87,8 @@ class DbBackupCommand extends Command {
      * @return mixed
      */
     public function fire() {
+        $this->timestamp = date($this->option('timestamp'));
+
         if ($this->isMissingArguments()) {
             $this->displayMissingArguments();
             $this->promptForMissingArgumentValues();
@@ -89,11 +98,10 @@ class DbBackupCommand extends Command {
         $destinations = [
             new Destination(
                 $this->option('destination'),
-                $this->option('destinationPath')
+                $this->option('destinationPath') . $this->timestamp
             )
         ];
 
-        $this->info('Dumping database and uploading...');
         $this->backupProcedure->run(
             $this->option('database'),
             $destinations,
@@ -106,7 +114,7 @@ class DbBackupCommand extends Command {
             $this->option('database'),
             $this->option('compression'),
             $this->option('destination'),
-            $root .DIRECTORY_SEPARATOR. $this->option('destinationPath')
+            $destinations[0]->destinationPath()
         ));
     }
 
@@ -191,7 +199,7 @@ class DbBackupCommand extends Command {
         $this->info(sprintf('Do you want to create a backup of <comment>%s</comment>, store it on <comment>%s</comment> at <comment>%s</comment> and compress it to <comment>%s</comment>?',
             $this->option('database'),
             $this->option('destination'),
-            $root . $this->option('destinationPath'),
+            $root . $this->option('destinationPath') . $this->timestamp,
             $this->option('compression')
         ));
         $this->line('');
@@ -224,6 +232,7 @@ class DbBackupCommand extends Command {
             ['destination', null, InputOption::VALUE_OPTIONAL, 'Destination configuration name', null],
             ['destinationPath', null, InputOption::VALUE_OPTIONAL, 'File destination path', null],
             ['compression', null, InputOption::VALUE_OPTIONAL, 'Compression type', null],
+            ['timestamp', null, InputOption::VALUE_OPTIONAL, 'Append timestamp to filename', null],
         ];
     }
 }

--- a/src/DbBackupCommand.php
+++ b/src/DbBackupCommand.php
@@ -102,6 +102,7 @@ class DbBackupCommand extends Command {
             )
         ];
 
+        $this->info('Dumping database and uploading...');
         $this->backupProcedure->run(
             $this->option('database'),
             $destinations,


### PR DESCRIPTION
As discussed in https://github.com/backup-manager/laravel/issues/79

Adds an optional `--timestamp="{format}"` to the command.

This is 100% backwards compatible. If you dont include a timestamp option, it is blank and nothing is appended. You can continue to use the "original" way of doing timestamps if you want, but this at least starts moving people towards a static defined command.

I've also update the readme to give a better default using the new option.