### PR TITLE
Adjust table method declaration to match Illuminate\Console\Command::table

### DIFF
--- a/src/Laravel55Compatibility.php
+++ b/src/Laravel55Compatibility.php
@@ -14,7 +14,7 @@ trait Laravel55Compatibility {
      * @internal param string $style
      * @return void
      */
-    public function table($headers, $rows, $style = 'default') {
+    public function table($headers, $rows, $style = 'default', array $columnStyles = []) {
         try {
             $table = $this->getHelperSet()->get('table');
         } catch (InvalidArgumentException $error) {


### PR DESCRIPTION
Using this package with Laravel 5.5.13 produces the following error:

```
[ErrorException]
Declaration of BackupManager\Laravel\Laravel55Compatibility::table($headers, $rows, $style = 'default') 
should be compatible with 
Illuminate\Console\Command::table($headers, $rows, $tableStyle = 'default', array $columnStyles = Array)
```

This commit fixes this error by adjusting the method declaration to match Illuminate\Console\Command::table.