### PR TITLE
Lumen 5.5 Service Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,13 @@ To install into a Lumen project, first do the composer install then add the conf
 $app->configure('backup-manager');
 $app->register(BackupManager\Laravel\Lumen50ServiceProvider::class);
 
-// FOR LUMEN 5.1 AND ABOVE
+// FOR LUMEN 5.1 - 5.4
 $app->configure('backup-manager');
 $app->register(BackupManager\Laravel\LumenServiceProvider::class);
+
+// FOR LUMEN 5.5 AND ABOVE
+$app->configure('backup-manager');
+$app->register(BackupManager\Laravel\Lumen55ServiceProvider::class);
 ```
 
 Copy the `vendor/backup-manager/laravel/config/backup-manager.php` file to `config/backup-manager.php` and configure it to suit your needs.

--- a/src/Lumen55ServiceProvider.php
+++ b/src/Lumen55ServiceProvider.php
@@ -1,0 +1,118 @@
+<?php namespace BackupManager\Laravel;
+
+use BackupManager\Databases;
+use BackupManager\Filesystems;
+use BackupManager\Compressors;
+use Symfony\Component\Process\Process;
+use Illuminate\Support\ServiceProvider;
+use BackupManager\Config\Config;
+use BackupManager\ShellProcessing\ShellProcessor;
+
+/**
+ * Class BackupManagerServiceProvider
+ * @package BackupManager\Laravel
+ */
+class Lumen55ServiceProvider extends ServiceProvider {
+    use GetDatabaseConfig;
+
+    protected $defer = true;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register() {
+        $configPath = __DIR__ . '/../config/backup-manager.php';
+        $this->mergeConfigFrom($configPath, 'backup-manager');
+        $this->registerFilesystemProvider();
+        $this->registerDatabaseProvider();
+        $this->registerCompressorProvider();
+        $this->registerShellProcessor();
+        $this->registerArtisanCommands();
+    }
+
+    /**
+     * Register the filesystem provider.
+     *
+     * @return void
+     */
+    private function registerFilesystemProvider() {
+        $this->app->bind(\BackupManager\Filesystems\FilesystemProvider::class, function ($app) {
+            $provider = new Filesystems\FilesystemProvider(new Config($app['config']['backup-manager']));
+            $provider->add(new Filesystems\Awss3Filesystem);
+            $provider->add(new Filesystems\DropboxFilesystem);
+            $provider->add(new Filesystems\DropboxV2Filesystem);
+            $provider->add(new Filesystems\FtpFilesystem);
+            $provider->add(new Filesystems\LocalFilesystem);
+            $provider->add(new Filesystems\RackspaceFilesystem);
+            $provider->add(new Filesystems\SftpFilesystem);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the database provider.
+     *
+     * @return void
+     */
+    private function registerDatabaseProvider() {
+        $this->app->bind(\BackupManager\Databases\DatabaseProvider::class, function ($app) {
+            $provider = new Databases\DatabaseProvider($this->getDatabaseConfig($app['config']['database.connections']));
+            $provider->add(new Databases\MysqlDatabase);
+            $provider->add(new Databases\PostgresqlDatabase);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the compressor provider.
+     *
+     * @return void
+     */
+    private function registerCompressorProvider() {
+        $this->app->bind(\BackupManager\Compressors\CompressorProvider::class, function () {
+            $provider = new Compressors\CompressorProvider;
+            $provider->add(new Compressors\GzipCompressor);
+            $provider->add(new Compressors\NullCompressor);
+            return $provider;
+        });
+    }
+
+    /**
+     * Register the filesystem provider.
+     *
+     * @return void
+     */
+    private function registerShellProcessor() {
+        $this->app->bind(\BackupManager\ShellProcessing\ShellProcessor::class, function () {
+            return new ShellProcessor(new Process(''));
+        });
+    }
+
+    /**
+     * Register the artisan commands.
+     *
+     * @return void
+     */
+    private function registerArtisanCommands() {
+        $this->commands([
+            \BackupManager\Laravel\Laravel55DbBackupCommand::class,
+            \BackupManager\Laravel\Laravel55DbRestoreCommand::class,
+            \BackupManager\Laravel\Laravel55DbListCommand::class,
+        ]);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides() {
+        return [
+            \BackupManager\Filesystems\FilesystemProvider::class,
+            \BackupManager\Databases\DatabaseProvider::class,
+            \BackupManager\ShellProcessing\ShellProcessor::class,
+        ];
+    }
+}


### PR DESCRIPTION
Added a new provider to support compatibility with Lumen 5.5

>  Declaration of BackupManager\Laravel\Laravel51Compatibility::table($headers
>   , $rows, $style = 'default') should be compatible with Illuminate\Console\C
>   ommand::table($headers, $rows, $tableStyle = 'default', array $columnStyles
>    = Array)
