### PR TITLE
Update GetDatabaseConfig.php

### DIFF
--- a/src/GetDatabaseConfig.php
+++ b/src/GetDatabaseConfig.php
@@ -38,6 +38,8 @@ trait GetDatabaseConfig
                 'database' => $connection['database'],
                 'ignoreTables' => $connection['driver'] === 'mysql' && isset($connection['ignoreTables'])
                     ? $connection['ignoreTables'] : null,
+                // add additional options to dump-command (like '--max-allowed-packet')
+                'extraParams' => '--column-statistics=0',
             ];
         }, $connections);
         return new Config($mapped);


### PR DESCRIPTION
Please consider adding a way to include extra params for mysqldump, this is possible in backup-manager but not laravel: 
            ```// add additional options to dump-command (like '--max-allowed-packet')```
           ``` 'extraParams' => '--column-statistics=0',```

My pull request has `'--column-statistics=0'` hard coded for reasons detailed below, however I suggest that this should not be hard coded - provide a way for these values to be specified, possibly with another config file/array; `'extraParams' => $connection['extraParams'],`?

> add compatibility for mysql 8.0 where column-statistics is not present anymore and will cause backups to fail, this change is needed because backup manager allows extra params and it is possible to set `--column-statistics=0`, however backup-manager/laravel just passes the config from backup-manager - providing no opportunity for these extra params to be included