### PR TITLE
Move extra params definition to backup manager config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ php artisan vendor:publish --provider="BackupManager\Laravel\Laravel5ServiceProv
 
 The Backup Manager will make use of Laravel's database configuration. But, it won't know about any connections that might be tied to other environments, so it can be best to just list multiple connections in the `config/database.php` file.
 
+We can also add extra parameters on our backup manager commands by configuring extra params on `.env` file:
+
+```
+BACKUP_MANAGER_EXTRA_PARAMS="--column-statistics=0 --max-allowed-packet"
+```
+
 #### Lumen Configuration
 
 To install into a Lumen project, first do the composer install then add the configuration file loader and *ONE* of the following service providers to your `bootstrap/app.php`.

--- a/config/backup-manager.php
+++ b/config/backup-manager.php
@@ -58,4 +58,7 @@ return [
         'privateKey' => '',
         'root' => '',
     ],
+
+    // Add additional options to dump-command (like '--max-allowed-packet')
+    'command-extra-params' => '',
 ];

--- a/config/backup-manager.php
+++ b/config/backup-manager.php
@@ -60,5 +60,5 @@ return [
     ],
 
     // Add additional options to dump-command (like '--max-allowed-packet')
-    'command-extra-params' => '',
+    'command-extra-params' => env('BACKUP_MANAGER_EXTRA_PARAMS'),
 ];

--- a/src/GetDatabaseConfig.php
+++ b/src/GetDatabaseConfig.php
@@ -38,8 +38,7 @@ trait GetDatabaseConfig
                 'database' => $connection['database'],
                 'ignoreTables' => $connection['driver'] === 'mysql' && isset($connection['ignoreTables'])
                     ? $connection['ignoreTables'] : null,
-                // add additional options to dump-command (like '--max-allowed-packet')
-                'extraParams' => '',
+                'extraParams' => config('backup-manager.command-extra-params'),
             ];
         }, $connections);
         return new Config($mapped);

--- a/src/GetDatabaseConfig.php
+++ b/src/GetDatabaseConfig.php
@@ -39,7 +39,7 @@ trait GetDatabaseConfig
                 'ignoreTables' => $connection['driver'] === 'mysql' && isset($connection['ignoreTables'])
                     ? $connection['ignoreTables'] : null,
                 // add additional options to dump-command (like '--max-allowed-packet')
-                'extraParams' => '--column-statistics=0',
+                'extraParams' => '',
             ];
         }, $connections);
         return new Config($mapped);


### PR DESCRIPTION
This PR will be a fix for reported error after laravel 6 support. https://github.com/backup-manager/laravel/issues/118#issuecomment-529152723
```
BackupManager\ShellProcessing\ShellProcessFailed
mysqldump: [ERROR] unknown variable 'column-statistics=0'
```

This fix works for laravel 6 on MySQL 5.7 or MariaDB 10.2.

Kindly please review this @ShawnMcCool, @mitchellvanw.