### PR TITLE
Add support for laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
   "require": {
     "backup-manager/backup-manager": "^1.0",
     "php": ">=5.5.0",
-    "symfony/process": "^2.0||^3.0||^4.0",
-    "illuminate/support": "^4.0||^5.0||^6.0",
-    "illuminate/container": "^4.0||^5.0||^6.0",
-    "illuminate/console": "^4.0||^5.0||^6.0"
+    "symfony/process": "^2.0||^3.0||^4.0||^5.0",
+    "illuminate/support": "^4.0||^5.0||^6.0||^7.0",
+    "illuminate/container": "^4.0||^5.0||^6.0||^7.0",
+    "illuminate/console": "^4.0||^5.0||^6.0||^7.0"
   },
   "require-dev": {
     "mockery/mockery": "dev-master",

--- a/src/Laravel55ServiceProvider.php
+++ b/src/Laravel55ServiceProvider.php
@@ -97,7 +97,7 @@ class Laravel55ServiceProvider extends ServiceProvider {
      */
     private function registerShellProcessor() {
         $this->app->bind(\BackupManager\ShellProcessing\ShellProcessor::class, function () {
-            return new ShellProcessor(new Process('', null, null, null, null));
+            return new ShellProcessor(new Process([], null, null, null, null));
         });
     }
 


### PR DESCRIPTION
In this PR, we are adding support for laravel 7. Related to #125.

**How to test**

[Backup Manager](https://packagist.org/packages/backup-manager/backup-manager) now requires php ^7.3.
```
$ php -v
PHP 7.4.3 (cli) (built: Feb 23 2020 07:24:02) ( NTS )
```
Create new laravel project
```
$ laravel new backup_manager_test
```
Add repositories on `composer.json`
```
    "repositories": [
        {
            "type": "vcs",
            "url":  "https://github.com/nafiesl/backup-manager-laravel"
        }
    ],
``` 
Install the package
```
$ composer require backup-manager/laravel dev-laravel_7_support
```
See if the package successfully installed.