### PR TITLE
Laravel 8 Support and Beyond

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     "backup-manager/backup-manager": "^3.0",
     "php": "^7.3||^7.4",
     "symfony/process": "^3||^4||^5",
-    "illuminate/support": "^5.5||^6||^7||^8",
-    "illuminate/container": "^5.5||^6||^7||^8",
-    "illuminate/console": "^5.5||^6||^7||^8"
+    "illuminate/support": ">=5.5",
+    "illuminate/container": ">=5.5",
+    "illuminate/console": ">=5.5"
   },
   "require-dev": {
     "mockery/mockery": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     "backup-manager/backup-manager": "^3.0",
     "php": "^7.3||^7.4",
     "symfony/process": "^3||^4||^5",
-    "illuminate/support": "^5.5||^6||^7",
-    "illuminate/container": "^5.5||^6||^7",
-    "illuminate/console": "^5.5||^6||^7"
+    "illuminate/support": "^5.5||^6||^7||^8",
+    "illuminate/container": "^5.5||^6||^7||^8",
+    "illuminate/console": "^5.5||^6||^7||^8"
   },
   "require-dev": {
     "mockery/mockery": "dev-master",


### PR DESCRIPTION
In this PR, we are adding support for laravel 8.x and beyond. It will work on the upcoming laravel major release as well.

This PR tested on laravel 8 on this project https://github.com/nafiesl/silsilah/pull/61 (installed successfully, doing backup and restore in MySQL).